### PR TITLE
Rename variables after network module changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,14 @@ Example that creates 1 EKS-managed node group and 1 advanced node group:
 module "quortex-eks" {
   source = "quortex/eks-cluster/aws"
   
-  region = "eu-west-3"
-  name = "quortexcluster"
+  region             = "eu-west-3"
+  name               = "quortexcluster"
   kubernetes_version = "1.15"
   availability_zones = ["eu-west-3b", "eu-west-3c"]
 
   # values from the Quortex network module:
-  subnet_ids_master = module.network.master_subnet_ids 
-  subnet_ids_worker = module.network.worker_subnet_ids
-  vpc_id = module.network.vpc_id
+  subnet_ids = module.network.private_subnet_ids 
+  vpc_id     = module.network.vpc_id
   
   master_authorized_networks = {
     myipaddress = "98.235.24.130/32"
@@ -100,7 +99,7 @@ File a GitHub [issue](https://github.com/quortex/terraform-aws-eks-cluster/issue
 
 
   [logo]: https://storage.googleapis.com/quortex-assets/logo.webp
-  [infra_diagram]: https://storage.googleapis.com/quortex-assets/infra_aws_001.jpg
+  [infra_diagram]: https://storage.googleapis.com/quortex-assets/infra_aws_002.jpg
 
   [email]: mailto:info@quortex.io
 

--- a/kubernetes.tf
+++ b/kubernetes.tf
@@ -23,7 +23,7 @@ resource "aws_eks_cluster" "quortex" {
   version  = var.kubernetes_version
 
   vpc_config {
-    subnet_ids = var.subnet_ids_master
+    subnet_ids = var.subnet_ids
 
     # Public endpoint: enabled but restricted to an IP range list
     endpoint_public_access = true
@@ -50,7 +50,7 @@ resource "aws_eks_node_group" "quortex" {
   cluster_name    = aws_eks_cluster.quortex.name
   node_group_name = lookup(each.value, "name", "${var.cluster_name}_${each.key}")
   node_role_arn   = aws_iam_role.quortex_role_worker.arn
-  subnet_ids      = var.subnet_ids_worker
+  subnet_ids      = length(var.subnet_ids_worker) != 0 ? var.subnet_ids_worker : var.subnet_ids
 
   scaling_config {
     desired_size = lookup(each.value, "scaling_desired_size", lookup(each.value, "scaling_min_size", 1))

--- a/node_group_advanced.tf
+++ b/node_group_advanced.tf
@@ -95,7 +95,7 @@ resource "aws_autoscaling_group" "quortex_asg_advanced" {
   for_each = var.node_groups_advanced
 
   name                = lookup(each.value, "asg_name", "${var.cluster_name}_${each.key}")
-  vpc_zone_identifier = var.subnet_ids_worker
+  vpc_zone_identifier = length(var.subnet_ids_worker) != 0 ? var.subnet_ids_worker : var.subnet_ids
   desired_capacity    = lookup(each.value, "scaling_desired_size", lookup(each.value, "scaling_min_size", 1))
   max_size            = lookup(each.value, "scaling_max_size", 1)
   min_size            = lookup(each.value, "scaling_min_size", 1)

--- a/variables.tf
+++ b/variables.tf
@@ -54,14 +54,15 @@ variable "vpc_id" {
   description = "ID of the VPC this cluster should be attached to."
 }
 
-variable "subnet_ids_master" {
+variable "subnet_ids" {
   type        = list(string)
-  description = "The IDs of the subnets for the master nodes"
+  description = "The IDs of the subnets where nodes should be placed"
 }
 
 variable "subnet_ids_worker" {
   type        = list(string)
-  description = "The IDs of the subnets for the worker nodes"
+  description = "The IDs of the subnets where worker nodes should be placed. By default, the subnets are subnet_ids"
+  default     = []
 }
 
 variable "master_authorized_networks" {


### PR DESCRIPTION
The network module now creates public and private subnets. By default, both master and worker nodes use all the subnets in the common "subnet_ids" list. But it is possible to specify a different list for worker nodes in "subnet_ids_worker". This is useful to restrict the worker nodes to a single AZ, for example