### PR TITLE
Align Kubernetes version between master/worker defaults

### DIFF
--- a/node_group_advanced.tf
+++ b/node_group_advanced.tf
@@ -24,7 +24,7 @@ resource "aws_iam_instance_profile" "quortex" {
 data "aws_ami" "eks_worker_image" {
   filter {
     name   = "name"
-    values = ["amazon-eks-node-${var.kubernetes_cluster_version}-v*"]
+    values = ["amazon-eks-node-${local.kubernetes_cluster_version}-v*"]
   }
   most_recent = true
   owners      = ["self", "amazon"]

--- a/variables.tf
+++ b/variables.tf
@@ -51,8 +51,12 @@ variable "kubernetes_version" {
 
 variable "kubernetes_cluster_version" {
   type        = string
-  description = "Kubernetes version for worker nodes"
-  default     = "1.15"
+  description = "Kubernetes version for worker nodes. An empty string means the same Kubernetes version as the master's"
+  default     = ""
+}
+
+locals {
+  kubernetes_cluster_version = var.kubernetes_cluster_version == "" ? var.kubernetes_version : var.kubernetes_cluster_version
 }
 
 variable "kubernetes_cluster_image_id" {


### PR DESCRIPTION
Modify the default value of kubernetes_cluster_version, so that when only the master version is defined (var kubernetes_version), the same version is used for the workers.

Previously, the 1.15 version was hard-coded in the default of both variables.