### PR TITLE
Add spot_instance_pools argument to advanced node groups

### DIFF
--- a/node_group_advanced.tf
+++ b/node_group_advanced.tf
@@ -142,6 +142,7 @@ resource "aws_autoscaling_group" "quortex_asg_advanced" {
         on_demand_percentage_above_base_capacity = lookup(each.value, "on_demand_percentage_above_base_capacity", 0)
         spot_allocation_strategy                 = lookup(each.value, "spot_allocation_strategy", "capacity-optimized")
         spot_max_price                           = lookup(each.value, "spot_max_price", "")
+        spot_instance_pools                      = lookup(each.value, "spot_instance_pools", 0)
       }
 
       launch_template {


### PR DESCRIPTION
The spot instance pools argument must be set to 0 when "capacity-optimized" is used as the spot allocation strategy.

Sometimes when we do not explicitly define it to 0, it is set to 2 by the terraform AWS provider, and there is an error: "SpotInstancePools option is only available with the lowest-price allocation strategy".

+ update the node group examples in the README, after several modifications in the node group API.