### PR TITLE
Disable EKS-defined max number of pods per node

### DIFF
--- a/node_group_advanced.tf
+++ b/node_group_advanced.tf
@@ -167,6 +167,8 @@ resource "aws_autoscaling_group" "quortex_asg_advanced" {
     ignore_changes = [
       # ignore changes to the cluster size, because it can be changed by autoscaling
       desired_capacity,
+      load_balancers,
+      target_group_arns
     ]
   }
 

--- a/node_group_advanced.tf
+++ b/node_group_advanced.tf
@@ -117,7 +117,7 @@ resource "aws_launch_template" "quortex_launch_tpl" {
             )
           : "${k}=${v}"]
         )
-        use_max_pods = var.node_eks_max_pods
+        use_max_pods = var.node_use_max_pods
       }
     )
   )

--- a/node_group_advanced.tf
+++ b/node_group_advanced.tf
@@ -88,6 +88,8 @@ resource "aws_launch_template" "quortex_launch_tpl" {
   image_id      = local.ami_id_worker
   instance_type = each.value.instance_types[0]
 
+  update_default_version = true
+
   user_data = base64encode(
     templatefile(
       "${path.module}/userdata.sh.tpl",

--- a/node_group_advanced.tf
+++ b/node_group_advanced.tf
@@ -115,6 +115,7 @@ resource "aws_launch_template" "quortex_launch_tpl" {
             )
           : "${k}=${v}"]
         )
+        use_max_pods = var.node_eks_max_pods
       }
     )
   )

--- a/userdata.sh.tpl
+++ b/userdata.sh.tpl
@@ -1,6 +1,7 @@
 #!/bin/bash 
 set -ex 
 /etc/eks/bootstrap.sh ${cluster_name} \
+  --use-max-pods ${use_max_pods} \
   --kubelet-extra-args '--node-labels=${node_labels} --register-with-taints=${node_taints} ${kubelet_more_extra_args}' \
   --b64-cluster-ca ${base64_cluster_ca} \
   --apiserver-endpoint ${api_server_url}

--- a/variables.tf
+++ b/variables.tf
@@ -105,7 +105,7 @@ variable "node_groups_advanced" {
   description = "[EXPERIMENTAL] Node groups that are not managed via EKS. The nodes are attached to the cluster with userdata passed to the instance boot script. More options are available than with EKS-managed node groups (taints, spot instances...). Defined as a map where the key defines the node group name, and the value is a map containing the node group parameters."
 }
 
-variable "node_eks_max_pods" {
+variable "node_use_max_pods" {
   type        = bool
   default     = true
   description = "Set to false to prevent EKS from setting --max-pods in Kubelet config. By default, EKS sets the maximum number of pods that can run on the node, based on the instance type. Disabling this can be useful when using a CNI other than the default, like Calico."

--- a/variables.tf
+++ b/variables.tf
@@ -105,6 +105,12 @@ variable "node_groups_advanced" {
   description = "[EXPERIMENTAL] Node groups that are not managed via EKS. The nodes are attached to the cluster with userdata passed to the instance boot script. More options are available than with EKS-managed node groups (taints, spot instances...). Defined as a map where the key defines the node group name, and the value is a map containing the node group parameters."
 }
 
+variable "node_eks_max_pods" {
+  type        = bool
+  default     = true
+  description = "Set to false to prevent EKS from setting --max-pods in Kubelet config. By default, EKS sets the maximum number of pods that can run on the node, based on the instance type. Disabling this can be useful when using a CNI other than the default, like Calico."
+}
+
 variable "instance_profile_name" {
   type        = string
   description = "A name for the instance profile resource in AWS. Used only when node_groups_advanced is used."

--- a/versions.tf
+++ b/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    aws = ">= 2.38.0"
+    aws = ">= 2.70.0"
   }
 }


### PR DESCRIPTION
**Add a variable "node_eks_max_pods"**

When setting this variable to false, AWS-EKS will not set a max number of pods that is based on the instance type, in the Kubelet config.

This is useful when using the Calico CNI to overcome the IP addresses limitations.

This changes only the launch template: the existing nodes will not be affected, nodes will need to be roll-updated.

Limitation: only the node groups non-managed by EKS ("node_groups_advanced") will benefit from this setting. Currently there is no way to disable max-pods with managed node groups.

**Update automatically the launch template to use latest version**

Without this setting, the new nodes will not use the latest version of the launch templates.

Note: the nodes will still need to be re-created to get the launch template updates.