### PR TITLE
Fix: add custom tags on managed node's ASG (fixes scale-up by the autoscaler)

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -19,5 +19,6 @@ terraform {
 
   required_providers {
     aws = ">= 2.70.0"
+    null = ">= 3.1.0"
   }
 }


### PR DESCRIPTION
The tags specified on the resource type "aws_eks_node_group" are not propagated to the ASG that represents this node group (issue https://github.com/aws/containers-roadmap/issues/608).

As a workaround, we add tags to the ASG after the nodegroup creation/updates using the AWS command-line.

This will fix scaling up from 0, in EKS-managed node groups, when pods have affinities/nodeSelectors defined on custom tags.