### PR TITLE
Fix/autoscaler role

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -61,3 +61,8 @@ output "ebs_csi_driver_role_arn" {
   value       = try(aws_iam_role.ebs_csi_driver[0].arn, null)
   description = "The ARN identifier of the role created in AWS for the Amazon EBS CSI driver."
 }
+
+output "cluster_autoscaler_role_arn" {
+  value       = try(aws_iam_role.quortex_role_autoscaler[0].arn, null)
+  description = "The ARN identifier of the role created in AWS for the Cluster Autoscaler."
+}

--- a/role-autoscaler.tf
+++ b/role-autoscaler.tf
@@ -17,7 +17,7 @@ resource "aws_iam_role" "quortex_role_autoscaler" {
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "${local.cluster_oidc_issuer}:sub": "system:serviceaccount:kube-system:${var.autoscaler_sa_name}"
+          "${local.cluster_oidc_issuer}:sub": "system:serviceaccount:${var.autoscaler_sa.namespace}:${var.autoscaler_sa.name}"
         }
       }
     }

--- a/role-autoscaler.tf
+++ b/role-autoscaler.tf
@@ -1,7 +1,7 @@
 
 resource "aws_iam_role" "quortex_role_autoscaler" {
   count       = var.handle_iam_resources ? 1 : 0
-  name        = var.worker_role_name
+  name        = var.autoscaler_role_name
   description = "IAM Role to allow the autoscaler service account to manage AWS Autoscaling."
   tags        = var.tags
 

--- a/role-autoscaler.tf
+++ b/role-autoscaler.tf
@@ -1,0 +1,61 @@
+
+resource "aws_iam_role" "quortex_role_autoscaler" {
+  count       = var.handle_iam_resources ? 1 : 0
+  name        = var.worker_role_name
+  description = "IAM Role to allow the autoscaler service account to manage AWS Autoscaling."
+  tags        = var.tags
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.cluster_oidc_issuer}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "${local.cluster_oidc_issuer}:sub": "system:serviceaccount:kube-system:${var.autoscaler_sa_name}"
+        }
+      }
+    }
+  ]
+}
+POLICY
+}
+
+### Attach a new policy for the cluster-autoscaler role
+
+resource "aws_iam_policy" "quortex_autoscaler_policy" {
+  count       = var.handle_iam_resources ? 1 : 0
+  description = "Allow the autoscaler to make calls to the AWS APIs."
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeLaunchConfigurations",
+                "autoscaling:DescribeTags",
+                "autoscaling:SetDesiredCapacity",
+                "autoscaling:TerminateInstanceInAutoScalingGroup",
+                "ec2:DescribeLaunchTemplateVersions"
+            ],
+            "Resource": "*",
+            "Effect": "Allow"
+        }
+    ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "quortex_autoscaler_policy_attach" {
+  count      = var.handle_iam_resources ? 1 : 0
+  role       = aws_iam_role.quortex_role_autoscaler[0].name
+  policy_arn = aws_iam_policy.quortex_autoscaler_policy[0].arn
+}

--- a/roles-worker.tf
+++ b/roles-worker.tf
@@ -59,40 +59,6 @@ resource "aws_iam_role_policy_attachment" "quortex-AmazonEC2ContainerRegistryRea
   role       = aws_iam_role.quortex_role_worker[0].name
 }
 
-### Attach a new policy for the cluster-autoscaler to the worker role
-
-resource "aws_iam_policy" "quortex-autoscaler-policy" {
-  count       = var.handle_iam_resources ? 1 : 0
-  description = "Allow the cluster autoscaler to make calls to the AWS APIs."
-
-  policy = <<POLICY
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": [
-                "autoscaling:DescribeAutoScalingGroups",
-                "autoscaling:DescribeAutoScalingInstances",
-                "autoscaling:DescribeLaunchConfigurations",
-                "autoscaling:DescribeTags",
-                "autoscaling:SetDesiredCapacity",
-                "autoscaling:TerminateInstanceInAutoScalingGroup",
-                "ec2:DescribeLaunchTemplateVersions"
-            ],
-            "Resource": "*",
-            "Effect": "Allow"
-        }
-    ]
-}
-POLICY
-}
-
-resource "aws_iam_role_policy_attachment" "quortex-autoscaler-policy-attach" {
-  count      = var.handle_iam_resources ? 1 : 0
-  role       = aws_iam_role.quortex_role_worker[0].name
-  policy_arn = aws_iam_policy.quortex-autoscaler-policy[0].arn
-}
-
 ### Attach a new policy for the cloudwatch-exporter to the worker role
 
 resource "aws_iam_policy" "quortex-cloudwatch-policy" {
@@ -111,7 +77,7 @@ resource "aws_iam_policy" "quortex-cloudwatch-policy" {
                 "cloudwatch:GetMetricData",
                 "tag:GetResources"
             ],
-            "Resource": "*", 
+            "Resource": "*",
             "Effect": "Allow"
         }
     ]

--- a/variables.tf
+++ b/variables.tf
@@ -38,10 +38,17 @@ variable "autoscaler_role_name" {
   default     = "quortex-autoscaler"
 }
 
-variable "autoscaler_sa_name" {
-  type        = string
+variable "autoscaler_sa" {
   description = "Service Account name for Autoscaler"
-  default     = "cluster-autoscaler-sa"
+
+  type = object({
+    namespace = string
+    name      = string
+  })
+  default = {
+    namespace = "kube-system"
+    name      = "cluster-autoscaler-sa"
+  }
 }
 
 variable "ebs_csi_driver_role_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -38,6 +38,12 @@ variable "autoscaler_role_name" {
   default     = "quortex-autoscaler"
 }
 
+variable "autoscaler_sa_name" {
+  type        = string
+  description = "Service Account name for Autoscaler"
+  default     = "cluster-autoscaler-sa"
+}
+
 variable "ebs_csi_driver_role_name" {
   type        = string
   description = "A name to be used as the AWS resource name for the Amazon EBS CSI Driver role."


### PR DESCRIPTION
Tested on PRL/small, works fine -> autoscaler is bound to a Kube serviceAccount which itself is bound to an AWS role.