### PR TITLE
Fix cluster autoscaler role for 1.24 and up

### DIFF
--- a/role-autoscaler.tf
+++ b/role-autoscaler.tf
@@ -27,31 +27,54 @@ POLICY
 }
 
 ### Attach a new policy for the cluster-autoscaler role
+# Based of https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md
+# Inspired by https://github.com/terraform-aws-modules/terraform-aws-iam/blob/263426fbb6cb8b0d59fb6b2a86168047ff1e58ac/modules/iam-role-for-service-accounts-eks/policies.tf#L48
+
+data "aws_iam_policy_document" "cluster_autoscaler" {
+  count = var.handle_iam_resources ? 1 : 0
+
+  statement {
+    actions = [
+      # For cluster-autoscaler
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeScalingActivities",
+      "autoscaling:DescribeTags",
+      "ec2:DescribeLaunchTemplateVersions",
+      "ec2:DescribeInstanceTypes",
+      "ec2:DescribeImages",
+      "ec2:GetInstanceTypesFromInstanceRequirements",
+      "eks:DescribeNodegroup"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+      "autoscaling:UpdateAutoScalingGroup",
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "autoscaling:ResourceTag/kubernetes.io/cluster/${aws_eks_cluster.quortex.id}"
+      values   = ["owned"]
+    }
+  }
+}
 
 resource "aws_iam_policy" "quortex_autoscaler_policy" {
-  count       = var.handle_iam_resources ? 1 : 0
-  description = "Allow the autoscaler to make calls to the AWS APIs."
+  count = var.handle_iam_resources ? 1 : 0
 
-  policy = <<POLICY
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": [
-                "autoscaling:DescribeAutoScalingGroups",
-                "autoscaling:DescribeAutoScalingInstances",
-                "autoscaling:DescribeLaunchConfigurations",
-                "autoscaling:DescribeTags",
-                "autoscaling:SetDesiredCapacity",
-                "autoscaling:TerminateInstanceInAutoScalingGroup",
-                "ec2:DescribeLaunchTemplateVersions"
-            ],
-            "Resource": "*",
-            "Effect": "Allow"
-        }
-    ]
-}
-POLICY
+  description = "Allow the autoscaler to make calls to the AWS APIs."
+  policy      = data.aws_iam_policy_document.cluster_autoscaler[0].json
+
+  tags = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "quortex_autoscaler_policy_attach" {


### PR DESCRIPTION
- To support 1.24.0 and above,`eks:DescribeNodegroup` was added to allow pulling labels and taints by API from managed node groups instead of using tags, and `autoscaling:DescribeScalingActivities` was added to avoid waiting the 15min of timeout if an ASG has no capacity before trying another ASG.
- To support 1.25.0 and above, `ec2:DescribeImages` and `ec2:GetInstanceTypesFromInstanceRequirements` were added to support AWS instance types requirements.
- To keep older versions, `autoscaling:DescribeTags` is kept, even if it is not needed from 1.24.1.