### PR TITLE
update local to fix bug if a nodegroup doesn't have labels

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ locals {
         nodegroup : key,
         "k8s.io/cluster-autoscaler/node-template/label/nodegroup" : key
         },
-        merge(local.node_group_labels[0][key]...),
+        length(local.node_group_labels) > 0 && try(local.node_group_labels[0][key], null) != null ? merge(local.node_group_labels[0][key]...) : {},
         merge(local.node_groups_tags[key]),
         var.tags,
         var.compute_tags


### PR DESCRIPTION
Only tested the make infra with 
variables:
        node_groups:
          test:
            scaling_max_size: 2
            subnet_ids: [
              "priv-eu-west-1b"
            ]
            labels:
              test: "true"
 and 
 variables:
        node_groups:
          test:
            scaling_max_size: 2
            subnet_ids: [
              "priv-eu-west-1b"
            ]
            
in my haddock